### PR TITLE
refactor: remove obsolete code

### DIFF
--- a/src/routes/kontakt.svelte
+++ b/src/routes/kontakt.svelte
@@ -3,14 +3,9 @@
   import { onMount } from 'svelte';
   let map;
   onMount(() => {
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = 'https://unpkg.com/leaflet@1.6.0/dist/leaflet.css';
-    link.onload = () => loadMap();
-    document.head.appendChild(link);
+    loadMap();
     return () => {
       map.remove();
-      link.parentNode.removeChild(link);
     };
   });
 


### PR DESCRIPTION
The user on Stackoverflow asked if there is a better way to include the
stylesheet. You're importing it twice here.

https://stackoverflow.com/questions/61359780/using-leaflet-in-a-svelte-app-the-correct-way